### PR TITLE
response view first look

### DIFF
--- a/src/containers/ReviewModal/GradingRubric.jsx
+++ b/src/containers/ReviewModal/GradingRubric.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import {
+    Card
+} from '@edx/paragon';
+
+/**
+ * <GradingRubric />
+ */
+export const GradingRubric = ({
+}) => {
+    return (
+        <div className="gradding-rubric-container">
+            <Card className="grading-rubric-card">
+                <Card.Body>
+                    <h3>Rubric</h3>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                    <p>Start grading</p>
+                </Card.Body>
+            </Card>
+        </div>
+    );
+}
+
+GradingRubric.defaultProps = {};
+GradingRubric.propTypes = {
+    text: PropTypes.node.isRequired
+};
+
+export const mapStateToProps = (state) => ({
+});
+
+export const mapDispatchToProps = {
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(GradingRubric);

--- a/src/containers/ReviewModal/GradingRubric.jsx
+++ b/src/containers/ReviewModal/GradingRubric.jsx
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import {
-    Card
+    Card,
+    Button,
+    Form,
 } from '@edx/paragon';
 
 /**
@@ -12,54 +14,70 @@ import {
 export const GradingRubric = ({
 }) => {
     return (
-        <div className="gradding-rubric-container">
-            <Card className="grading-rubric-card">
-                <Card.Body>
-                    <h3>Rubric</h3>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                    <p>Start grading</p>
-                </Card.Body>
-            </Card>
-        </div>
+        <Card className="grading-rubric-card">
+            <Card.Body className="grading-rubric-body">
+                <h3>Rubric</h3>
+                <hr />
+                <Form.Group>
+                    <Form.Label>Which Color?</Form.Label>
+                    <Form.RadioSet
+                        name="colors"
+                    >
+                        <Form.Radio value="red">Red</Form.Radio>
+                        <Form.Radio value="green">Green</Form.Radio>
+                        <Form.Radio value="blue">Blue</Form.Radio>
+                        <Form.Radio value="cyan" disabled>Cyan</Form.Radio>
+                    </Form.RadioSet>
+                </Form.Group>
+                <Form.Group>
+                    <Form.Control
+                        floatingLabel="Comments"
+                    />
+                </Form.Group>
+                <Form.Group isInvalid>
+                    <Form.Label>Which Color?</Form.Label>
+                    <Form.RadioSet
+                        name="colors"
+                    >
+                        <Form.Radio value="red">Red</Form.Radio>
+                        <Form.Radio value="green">Green</Form.Radio>
+                        <Form.Radio value="blue">Blue</Form.Radio>
+                        <Form.Radio value="cyan" disabled>Cyan</Form.Radio>
+                    </Form.RadioSet>
+                    <Form.Control.Feedback type="invalid">
+                        Make a selection
+                    </Form.Control.Feedback>
+                </Form.Group>
+                <Form.Group isInvalid>
+                    <Form.Control
+                        floatingLabel="Comments"
+                    />
+                    <Form.Control.Feedback type="invalid">
+                        Make a comment
+                    </Form.Control.Feedback>
+                </Form.Group>
+                <Form.Group>
+                    <Form.Label>Which Color?</Form.Label>
+                    <Form.RadioSet
+                        name="colors"
+                    >
+                        <Form.Radio value="red">Red</Form.Radio>
+                        <Form.Radio value="green">Green</Form.Radio>
+                        <Form.Radio value="blue">Blue</Form.Radio>
+                        <Form.Radio value="cyan" disabled>Cyan</Form.Radio>
+                    </Form.RadioSet>
+                </Form.Group>
+                <Form.Group>
+                    <Form.Control
+                        floatingLabel="Comments"
+                    />
+                </Form.Group>
+                
+            </Card.Body>
+            <div className="grading-rubric-footer">
+                <Button>Submit Grade</Button>
+            </div>
+        </Card>
     );
 }
 

--- a/src/containers/ReviewModal/ResponseContainer.jsx
+++ b/src/containers/ReviewModal/ResponseContainer.jsx
@@ -19,15 +19,13 @@ export const ResponseContainer = ({
     text
 }) => {
     return (
-        <div className="response-container">
-            <Card className="response-card">
-                <Card.Body>
+        <Card className="response-card">
+            <Card.Body>
                 {text}
                 {text}
                 {text}
-                </Card.Body>
-            </Card>
-        </div>
+            </Card.Body>
+        </Card>
     );
 }
 

--- a/src/containers/ReviewModal/ResponseContainer.jsx
+++ b/src/containers/ReviewModal/ResponseContainer.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import {
+    Card
+} from '@edx/paragon';
+
+import createDOMPurify from 'dompurify';
+
+import parse from 'html-react-parser';
+
+import selectors from 'data/selectors';
+
+/**
+ * <ResponseContainer />
+ */
+export const ResponseContainer = ({
+    text
+}) => {
+    return (
+        <div className="response-container">
+            <Card className="response-card">
+                <Card.Body>
+                {text}
+                {text}
+                {text}
+                </Card.Body>
+            </Card>
+        </div>
+    );
+}
+
+ResponseContainer.defaultProps = {};
+ResponseContainer.propTypes = {
+    text: PropTypes.node.isRequired
+};
+
+const purify = createDOMPurify(window);
+
+export const mapStateToProps = (state) => ({
+    text: parse(purify.sanitize(selectors.submissions.selectedResponse(state)?.text))
+});
+
+export const mapDispatchToProps = {
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ResponseContainer);

--- a/src/containers/ReviewModal/ReviewActions.jsx
+++ b/src/containers/ReviewModal/ReviewActions.jsx
@@ -30,32 +30,30 @@ export const ReviewActions = ({
   onShowGradingRubricClick,
   showGradingRubric
 }) => (
-  <div className="review-actions">
-    <ActionRow>
-      <span className="review-actions-username">{username}{username}{username}{username}{username}
-        <StatusBadge status={status} />
-      </span>
-      <div className="review-actions-grading-group">
-        <Button variant="outline-primary" onClick={onShowGradingRubricClick}>{showGradingRubric ? 'Hide' : 'Show'} Rubric</Button>
-        <Button
-          variant="primary"
-          iconAfter={showGradingRubric ? Close : Edit}
-          onClick={onShowGradingRubricClick}
-        >{showGradingRubric ? 'Stop Grading' : 'Start Grading'}</Button>
-        <ActionRow.Spacer />
-        <IconButton size="inline" src={ChevronLeft} iconAs={Icon} onClick={() => {
-          loadPrev();
-          prefetchPrev();
-        }} />
-        <span>{activeIndex + 1} of {selected.length}</span>
-        <IconButton size="inline" src={ChevronRight} iconAs={Icon} onClick={() => {
-          loadNext();
-          prefetchNext();
-        }} />
+  <ActionRow className="review-actions">
+    <span className="review-actions-username">{username}{username}{username}{username}{username}
+      <StatusBadge className="ml-1" status={status} />
+    </span>
+    <div className="review-actions-grading-group">
+      <Button variant="outline-primary" onClick={onShowGradingRubricClick}>{showGradingRubric ? 'Hide' : 'Show'} Rubric</Button>
+      <Button
+        variant="primary"
+        iconAfter={showGradingRubric ? Close : Edit}
+        onClick={onShowGradingRubricClick}
+      >{showGradingRubric ? 'Stop Grading' : 'Start Grading'}</Button>
+      <ActionRow.Spacer />
+      <IconButton size="inline" src={ChevronLeft} iconAs={Icon} onClick={() => {
+        loadPrev();
+        prefetchPrev();
+      }} />
+      <span>{activeIndex + 1} of {selected.length}</span>
+      <IconButton size="inline" src={ChevronRight} iconAs={Icon} onClick={() => {
+        loadNext();
+        prefetchNext();
+      }} />
 
-      </div>
-    </ActionRow>
-  </div>
+    </div>
+  </ActionRow>
 );
 
 let submissionPropType = PropTypes.shape({

--- a/src/containers/ReviewModal/ReviewActions.jsx
+++ b/src/containers/ReviewModal/ReviewActions.jsx
@@ -5,39 +5,85 @@ import { connect } from 'react-redux';
 import {
   ActionRow,
   Button,
+  IconButton,
   Icon,
-  FullscreenModal,
-  Container,
 } from '@edx/paragon';
 
+import { ChevronLeft, ChevronRight, Edit, Close } from '@edx/paragon/icons';
+
+
 import selectors from 'data/selectors';
-import thunkActions from 'data/thunkActions';
 
 import StatusBadge from 'components/StatusBadge';
 import './ReviewModal.scss';
+import actions from 'data/actions';
+import thunkActions from 'data/thunkActions';
 
-export const ReviewActions = ({ submission: { status, username } }) => (
+export const ReviewActions = ({
+  submission: { status, username },
+  loadNext,
+  loadPrev,
+  activeIndex,
+  selected,
+  prefetchNext,
+  prefetchPrev,
+  onShowGradingRubricClick,
+  showGradingRubric
+}) => (
   <div className="review-actions">
     <ActionRow>
-      <span className="review-actions-username">{username}</span>
-      <StatusBadge className="review-actions-status" status={status} />
-      <ActionRow.Spacer />
-      <Button>Show Rubric</Button>
+      <span className="review-actions-username">{username}{username}{username}{username}{username}
+        <StatusBadge status={status} />
+      </span>
+      <div className="review-actions-grading-group">
+        <Button variant="outline-primary" onClick={onShowGradingRubricClick}>{showGradingRubric ? 'Hide' : 'Show'} Rubric</Button>
+        <Button
+          variant="primary"
+          iconAfter={showGradingRubric ? Close : Edit}
+          onClick={onShowGradingRubricClick}
+        >{showGradingRubric ? 'Stop Grading' : 'Start Grading'}</Button>
+        <ActionRow.Spacer />
+        <IconButton size="inline" src={ChevronLeft} iconAs={Icon} onClick={() => {
+          loadPrev();
+          prefetchPrev();
+        }} />
+        <span>{activeIndex + 1} of {selected.length}</span>
+        <IconButton size="inline" src={ChevronRight} iconAs={Icon} onClick={() => {
+          loadNext();
+          prefetchNext();
+        }} />
+
+      </div>
     </ActionRow>
   </div>
 );
+
+let submissionPropType = PropTypes.shape({
+  status: PropTypes.string.isRequired,
+  username: PropTypes.string.isRequired,
+})
+
 ReviewActions.propTypes = {
-  submission: PropTypes.shape({
-    status: PropTypes.string.isRequired,
-    username: PropTypes.string.isRequired,
-  }).isRequired,
+  submission: submissionPropType.isRequired,
+  loadNext: PropTypes.func.isRequired,
+  loadPrev: PropTypes.func.isRequired,
+  activeIndex: PropTypes.number.isRequired,
+  selected: PropTypes.arrayOf(submissionPropType).isRequired,
+  onShowGradingRubricClick: PropTypes.func.isRequired,
+  showGradingRubric: PropTypes.func.isRequired,
 };
 
 export const mapStateToProps = (state) => ({
   submission: selectors.submissions.currentSelection(state),
+  selected: selectors.submissions.selected(state),
+  activeIndex: selectors.submissions.activeIndex(state),
 });
 
 export const mapDispatchToProps = {
+  loadNext: actions.submissions.loadNext,
+  loadPrev: actions.submissions.loadPrev,
+  prefetchPrev: thunkActions.submissions.prefetchPrev,
+  prefetchNext: thunkActions.submissions.prefetchNext
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(ReviewActions);

--- a/src/containers/ReviewModal/ReviewModal.scss
+++ b/src/containers/ReviewModal/ReviewModal.scss
@@ -1,7 +1,61 @@
 @import "@edx/paragon/scss/core/core";
+
+// action reviews
 .review-actions {
   padding: map_get($spacers, 3);
+  flex-direction: row;
+
+  .review-actions-username {
+    flex-grow: 1;
+  }
+
+  .review-actions-grading-group {
+    margin-left: 0;
+    flex-shrink: 0;
+  }
 }
-#ora-esg-list-view {
-  padding: 20px;
+
+@include media-breakpoint-down(md) {
+  .review-actions {
+    flex-direction: column;
+    align-items: flex-start !important;
+  }
+}
+
+.fullscreen-modal-body {
+  background-color: $gray-300;
+  padding: inherit;
+
+  // text response
+  .response-container {
+    padding: map-get($map: $spacers, $key: 0);
+    max-width: map-get($map: $container-max-widths, $key: "sm");
+    margin: auto;
+    height: 100%;
+    .response-card {
+      height: 100%;
+      overflow-y: scroll;
+    }
+  }
+}
+
+@include media-breakpoint-down(sm) {
+  .fullscreen-modal-body {
+    padding: 0 !important;
+    overflow-y: hidden !important;
+
+    div:nth-child(2) {
+      height: 100%;
+    }
+
+    .response-container {
+      max-width: 100%;
+    }
+  }
+}
+
+.grading-rubric-card {
+  width: 320px;
+  max-height: 60vh;
+  overflow-y: scroll;
 }

--- a/src/containers/ReviewModal/ReviewModal.scss
+++ b/src/containers/ReviewModal/ReviewModal.scss
@@ -19,6 +19,11 @@
   .review-actions {
     flex-direction: column;
     align-items: flex-start !important;
+
+    & > * {
+      margin-bottom: map_get($spacers, 1) !important;
+    }
+
   }
 }
 
@@ -44,8 +49,11 @@
     padding: 0 !important;
     overflow-y: hidden !important;
 
-    div:nth-child(2) {
+    & > div:nth-child(2) {
       height: 100%;
+      .row, .col {
+        height: 100%;
+      }
     }
 
     .response-container {

--- a/src/containers/ReviewModal/ReviewModal.scss
+++ b/src/containers/ReviewModal/ReviewModal.scss
@@ -23,7 +23,6 @@
     & > * {
       margin-bottom: map_get($spacers, 1) !important;
     }
-
   }
 }
 
@@ -32,16 +31,18 @@
   padding: inherit;
 
   // text response
-  .response-container {
+  .response-card {
     padding: map-get($map: $spacers, $key: 0);
     max-width: map-get($map: $container-max-widths, $key: "sm");
-    margin: auto;
     height: 100%;
-    .response-card {
-      height: 100%;
-      overflow-y: scroll;
-    }
+    overflow-y: scroll;
   }
+}
+
+.content-block {
+  width: fit-content;
+  margin: auto;
+  height: 100%;
 }
 
 @include media-breakpoint-down(sm) {
@@ -51,19 +52,37 @@
 
     & > div:nth-child(2) {
       height: 100%;
-      .row, .col {
-        height: 100%;
-      }
-    }
 
-    .response-container {
-      max-width: 100%;
+      .row,
+      .col {
+        height: 100%;
+        padding: 0;
+      }
     }
   }
 }
 
 .grading-rubric-card {
   width: 320px;
-  max-height: 60vh;
-  overflow-y: scroll;
+  height: fit-content;
+  max-height: 70vh;
+  min-height: 320px;
+
+  .grading-rubric-header {
+    box-shadow: 0 0 0.25rem rgba(0, 0, 0, 0.3) !important;
+    display: flex;
+    justify-content: center;
+    padding: map-get($map: $spacers, $key: 3);
+  }
+
+  .grading-rubric-body {
+    overflow-y: scroll;
+  }
+
+  .grading-rubric-footer {
+    box-shadow: 0 0 0.25rem rgba(0, 0, 0, 0.3) !important;
+    display: flex;
+    justify-content: center;
+    padding: map-get($map: $spacers, $key: 3);
+  }
 }

--- a/src/containers/ReviewModal/index.jsx
+++ b/src/containers/ReviewModal/index.jsx
@@ -40,13 +40,14 @@ export const ReviewModal = ({
       onClose={() => setShowReview(false)}
       modalBodyClassName="fullscreen-modal-body"
     >
-      <Row>
-        <Col><ResponseContainer /></Col>
-        {
-          showGradingRubric && <Col><GradingRubric /></Col>
-        }
-      </Row>
-
+      <div class="content-block">
+        <Row>
+          <Col><ResponseContainer /></Col>
+          {
+            showGradingRubric && <GradingRubric />
+          }
+        </Row>
+      </div>
     </FullscreenModal>
   );
 }

--- a/src/containers/ReviewModal/index.jsx
+++ b/src/containers/ReviewModal/index.jsx
@@ -1,72 +1,66 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import {
   FullscreenModal,
-  Container,
+  Row,
+  Col,
 } from '@edx/paragon';
-
-import createDOMPurify from 'dompurify';
-import parse from 'html-react-parser';
 
 import selectors from 'data/selectors';
 import actions from 'data/actions';
-import thunkActions from 'data/thunkActions';
 
 import ReviewActions from './ReviewActions';
+import ResponseContainer from './ResponseContainer';
 
 import './ReviewModal.scss';
+import { GradingRubric } from './GradingRubric';
 
 /**
  * <ReviewModal />
  */
-export class ReviewModal extends React.Component {
-  constructor(props) {
-    super(props);
-    console.log('review modal');
-    console.log({ props });
-    this.purify = createDOMPurify(window);
-    this.onClose = this.onClose.bind(this);
+export const ReviewModal = ({
+  setShowReview,
+  oraName,
+  isOpen,
+}) => {
+  const [showGradingRubric, setshowGradingRubric] = useState(false)
+  const toggleShowGradingRubric = () => {
+    setshowGradingRubric(!showGradingRubric);
   }
 
-  get textContent() {
-    return parse(this.purify.sanitize(this.props.response.text));
-  }
+  return (
+    <FullscreenModal
+      title={oraName}
+      isOpen={isOpen}
+      beforeBodyNode={(
+        <ReviewActions onShowGradingRubricClick={toggleShowGradingRubric} showGradingRubric={showGradingRubric} />
+      )}
+      onClose={() => setShowReview(false)}
+      modalBodyClassName="fullscreen-modal-body"
+    >
+      <Row>
+        <Col><ResponseContainer /></Col>
+        {
+          showGradingRubric && <Col><GradingRubric /></Col>
+        }
+      </Row>
 
-  onClose() {
-    this.props.setShowReview(false);
-  }
-
-  render() {
-    return (
-      <FullscreenModal
-        title={this.props.oraName}
-        isOpen={this.props.isOpen}
-        beforeBodyNode={<ReviewActions />}
-        onClose={this.onClose}
-      >
-        <Container size="md">
-          {this.textContent}
-        </Container>
-      </FullscreenModal>
-    );
-  }
+    </FullscreenModal>
+  );
 }
+
 ReviewModal.defaultProps = {};
 ReviewModal.propTypes = {
   oraName: PropTypes.string.isRequired,
   isOpen: PropTypes.bool.isRequired,
-  response: PropTypes.shape({
-    text: PropTypes.node,
-  }).isRequired,
   setShowReview: PropTypes.func.isRequired,
 };
 
 export const mapStateToProps = (state) => ({
   isOpen: selectors.app.showReview(state),
-  oraName: selectors.app.oraName(state),
-  response: selectors.submissions.selectedResponse(state),
+  oraName: selectors.app.oraName(state)
 });
 
 export const mapDispatchToProps = {

--- a/src/data/reducers/submissions.js
+++ b/src/data/reducers/submissions.js
@@ -1,4 +1,5 @@
 import actions from 'data/actions';
+import thunkActions from 'data/thunkActions';
 
 const initialState = {
   list: {},
@@ -46,6 +47,7 @@ const grades = (state = initialState, { type, payload }) => {
       return { ...state, prev: payload };
 
     case actions.submissions.loadNext.toString():
+      if (state.activeIndex >= state.selected.length - 1) return state;
       return {
         ...state,
         prev: state.current,
@@ -57,6 +59,7 @@ const grades = (state = initialState, { type, payload }) => {
         next: null,
       };
     case actions.submissions.loadPrev.toString():
+      if ( state.activeIndex <= 0 )  return state;
       return {
         ...state,
         next: state.current,

--- a/src/data/thunkActions/app.js
+++ b/src/data/thunkActions/app.js
@@ -3,6 +3,7 @@ import { StrictDict } from 'utils';
 import actions from 'data/actions';
 import selectors from 'data/selectors';
 import api from 'data/services/lms/api';
+import { fetchSubmissionFromSelection } from './submissions';
 
 const locationId = window.location.pathname.slice(1);
 
@@ -14,44 +15,6 @@ export const initialize = () => (dispatch) => (
     dispatch(actions.submissions.loadList(response.submissions));
   })
 );
-
-export const prefetchPrev = () => (dispatch, getState) => (
-  api.fetchSubmission(selectors.submissions.prevSubmissionId(getState())).then((response) => {
-    dispatch(actions.submissions.preloadPrev(response.submission));
-  })
-);
-
-export const prefetchNext = () => (dispatch, getState) => (
-  api.fetchSubmission(selectors.submissions.nextSubmissionId(getState())).then((response) => {
-    dispatch(actions.submissions.preloadNext(response.submission));
-    if (selectors.submissions.activeIndex(getState()) > 0) {
-      return dispatch(prefetchPrev());
-    }
-    return true;
-  })
-);
-
-export const fetchSubmissionFromSelection = () => (dispatch, getState) => {
-  console.log({
-    fetchSubmission: selectors.submissions.selectedSubmissionId(getState()),
-  });
-  return (
-    api.fetchSubmission(
-      selectors.submissions.selectedSubmissionId(getState()),
-    ).then((response) => {
-      dispatch(actions.submissions.loadSubmission(response.submission));
-      const activeIndex = selectors.submissions.activeIndex(getState());
-      const selected = selectors.submissions.selected(getState());
-      if (activeIndex < selected.length - 1) {
-        return dispatch(prefetchNext());
-      }
-      if (activeIndex > 0) {
-        return dispatch(prefetchPrev());
-      }
-      return true;
-    })
-  );
-};
 
 export const loadSelectionForReview = (selection) => (dispatch) => {
   const submissions = selection.map(row => row.original);

--- a/src/data/thunkActions/index.js
+++ b/src/data/thunkActions/index.js
@@ -1,6 +1,8 @@
 import { StrictDict } from 'utils';
 import app from './app';
+import submissions from './submissions';
 
 export default StrictDict({
   app,
+  submissions
 });

--- a/src/data/thunkActions/submissions.js
+++ b/src/data/thunkActions/submissions.js
@@ -1,0 +1,40 @@
+import { StrictDict } from 'utils';
+
+import actions from 'data/actions';
+import selectors from 'data/selectors';
+import api from 'data/services/lms/api';
+
+export const prefetchPrev = () => (dispatch, getState) => {
+    const prevSubmissionId = selectors.submissions.prevSubmissionId(getState());
+    prevSubmissionId && api.fetchSubmission(prevSubmissionId).then((response) => {
+        dispatch(actions.submissions.preloadPrev(response.submission));
+    })
+};
+
+export const prefetchNext = () => (dispatch, getState) => {
+    const nextSubmissionId = selectors.submissions.nextSubmissionId(getState())
+    nextSubmissionId && api.fetchSubmission(nextSubmissionId).then((response) => {
+        dispatch(actions.submissions.preloadNext(response.submission));
+    })
+};
+
+export const fetchSubmissionFromSelection = () => (dispatch, getState) => {
+    console.log({
+        fetchSubmission: selectors.submissions.selectedSubmissionId(getState()),
+    });
+    return (
+        api.fetchSubmission(
+            selectors.submissions.selectedSubmissionId(getState()),
+        ).then((response) => {
+            dispatch(actions.submissions.loadSubmission(response.submission));
+            dispatch(prefetchNext());
+            dispatch(prefetchPrev());
+            return true;
+        })
+    );
+};
+
+export default StrictDict({
+    prefetchPrev,
+    prefetchNext,
+});


### PR DESCRIPTION
First look of the response view for [AU-103](https://openedx.atlassian.net/browse/AU-103)

✅   with AC:
- [x] Full screen header
- [x] close button
- [x] Action bar
- [x] Response text fixed at `sm` size
![Screen Shot 2021-09-20 at 2 56 10 PM](https://user-images.githubusercontent.com/83240113/134058862-34679e42-e2d5-40ea-a6e8-ff0c96c9733c.png)


✅   for responsive AC:
- [x] Action row show as stack 
- [x] Long username push badge to a new line instead of ellipsis
- [x] Response text become 100% without padding
- [x] Scrollable become independent of the modal body 

![Screen Shot 2021-09-20 at 3 01 04 PM](https://user-images.githubusercontent.com/83240113/134059535-55e8591e-c6c8-4909-9f3e-2a27e4ee5d85.png)


❓ Not covered case that isn't part of the AC:

- When the username is long, is display username like that is desirable? It is probably part of the about pushing badge to another line. I just need to make sure.
![Screen Shot 2021-09-20 at 3 16 45 PM](https://user-images.githubusercontent.com/83240113/134061324-4d6522f3-512b-4936-b04c-0abecea84d9f.png)

- Very similar case except screen size. Is this desirable?
![Screen Shot 2021-09-20 at 3 20 04 PM](https://user-images.githubusercontent.com/83240113/134061599-e8d862ae-06d6-47a5-bc72-d280acbbebcf.png)

