### PR TITLE
make top level rubric container responsive

### DIFF
--- a/src/containers/ReviewModal/ReviewModal.scss
+++ b/src/containers/ReviewModal/ReviewModal.scss
@@ -30,6 +30,14 @@
   background-color: $gray-300 !important;
   padding: inherit;
 
+  & > div.pgn__modal-body-content {
+    height: 100%;
+
+    .row {
+      height: 100%;
+    }
+  }
+
   .content-block {
     width: fit-content;
     margin: auto;
@@ -40,25 +48,22 @@
   .response-card {
     padding: map-get($spacers, 0);
     max-width: map-get($container-max-widths, "sm");
-    height: 100%;
     overflow-y: scroll;
+    height: fit-content;
   }
 }
-
 
 @include media-breakpoint-down(sm) {
   .review-modal-body {
     padding: 0 !important;
     overflow-y: hidden !important;
 
-    & > div:nth-child(2) {
+    .response-card {
       height: 100%;
+    }
 
-      .row,
-      .col {
-        height: 100%;
-        padding: 0;
-      }
+    .content-block .col {
+      padding: 0;
     }
   }
 }
@@ -66,8 +71,7 @@
 .grading-rubric-card {
   width: 320px;
   height: fit-content;
-  max-height: 70vh;
-  min-height: 320px;
+  max-height: 100%;
 
   .grading-rubric-header {
     box-shadow: 0 0 0.25rem rgba(0, 0, 0, 0.3) !important;


### PR DESCRIPTION
[AU-104](https://openedx.atlassian.net/browse/AU-104)
✅  with AC:

<img width="989" alt="Screen Shot 2021-09-22 at 6 06 26 PM" src="https://user-images.githubusercontent.com/83240113/134508933-3501bb56-a9f7-4dcc-b755-9e4d810ebc83.png">
<img width="722" alt="Screen Shot 2021-09-22 at 6 07 10 PM" src="https://user-images.githubusercontent.com/83240113/134508966-63b5a73c-202c-49cc-89ab-5e83fb26bea5.png">

My nit maybe not important but the bottom scroll doesn't have padding. It is kind of complicate to solve.
<img width="988" alt="Screen Shot 2021-09-22 at 6 06 39 PM" src="https://user-images.githubusercontent.com/83240113/134508954-4a7285bc-095e-427b-aea2-40ee9975d9db.png">

Additionally, rubric isn't sticky is an inefficient design decision in my opinion.