### PR TITLE
update grading data api

### DIFF
--- a/src/containers/ListView/index.jsx
+++ b/src/containers/ListView/index.jsx
@@ -102,7 +102,7 @@ export class ListView extends React.Component {
             },
             {
               Header: 'Grading Status',
-              accessor: 'gradeStatus',
+              accessor: 'gradingStatus',
               Cell: this.formatStatus,
               Filter: MultiSelectDropdownFilter,
               filter: 'includesValue',
@@ -128,7 +128,7 @@ ListView.propTypes = {
   listData: PropTypes.arrayOf(PropTypes.shape({
     username: PropTypes.string,
     dateSubmitted: PropTypes.number,
-    gradeStatus: PropTypes.string,
+    gradingStatus: PropTypes.string,
     grade: PropTypes.shape({
       pointsEarned: PropTypes.number,
       pointsPossible: PropTypes.number,

--- a/src/containers/ReviewModal/ReviewActions.jsx
+++ b/src/containers/ReviewModal/ReviewActions.jsx
@@ -10,6 +10,7 @@ import { Edit } from '@edx/paragon/icons';
 
 import actions from 'data/actions';
 import selectors from 'data/selectors';
+import thunkActions from 'data/thunkActions';
 
 import StatusBadge from 'components/StatusBadge';
 import SubmissionNavigation from './SubmissionNavigation';
@@ -20,6 +21,7 @@ export const ReviewActions = ({
   toggleShowRubric,
   showRubric,
   username,
+  startGrading,
 }) => (
   <div>
     <ActionRow className="review-actions">
@@ -31,7 +33,7 @@ export const ReviewActions = ({
         <Button variant="outline-primary" onClick={toggleShowRubric}>
           {showRubric ? 'Hide' : 'Show'} Rubric
         </Button>
-        <Button variant="primary" iconAfter={Edit}>Start Grading</Button>
+        <Button variant="primary" iconAfter={Edit} onClick={startGrading}>Start Grading</Button>
         <SubmissionNavigation />
       </div>
     </ActionRow>
@@ -42,6 +44,7 @@ ReviewActions.propTypes = {
   username: PropTypes.string.isRequired,
   showRubric: PropTypes.bool.isRequired,
   toggleShowRubric: PropTypes.func.isRequired,
+  startGrading: PropTypes.func.isRequired,
 };
 
 export const mapStateToProps = (state) => ({
@@ -52,6 +55,7 @@ export const mapStateToProps = (state) => ({
 
 export const mapDispatchToProps = {
   toggleShowRubric: actions.app.toggleShowRubric,
+  startGrading: thunkActions.grading.startGrading,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(ReviewActions);

--- a/src/containers/ReviewModal/ReviewModal.scss
+++ b/src/containers/ReviewModal/ReviewModal.scss
@@ -48,7 +48,7 @@
   .response-card {
     padding: map-get($spacers, 0);
     max-width: map-get($container-max-widths, "sm");
-    overflow-y: scroll;
+    overflow-y: hidden;
     height: fit-content;
   }
 }

--- a/src/containers/ReviewModal/StartGradingButton.jsx
+++ b/src/containers/ReviewModal/StartGradingButton.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import {
+  Button,
+} from '@edx/paragon';
+import { Cancel, Highlight } from '@edx/paragon/icons';
+
+import actions from 'data/actions';
+import selectors from 'data/selectors';
+import thunkActions from 'data/thunkActions';
+import { gradingStatuses as statuses } from 'data/services/lms/constants';
+
+export const StartGradingButton = ({
+  gradeStatus,
+  startGrading,
+  stopGrading,
+}) => {
+  const buttonArgs = {
+    [statuses.ungraded]: {
+      label: 'Start Grading',
+      iconAfter: Highlight,
+      onClick: startGrading,
+    },
+    [statuses.graded]: {
+      label: 'Override grade',
+      iconAfter: Highlight,
+      onClick: startGrading,
+    },
+    [statuses.inProgress]: {
+      label: 'Stop grading this response',
+      iconAfter: Cancel,
+      onClick: stopGrading,
+    },
+  };
+  if (gradeStatus === statuses.locked) {
+    return null;
+  }
+  const args = buttonArgs[gradeStatus];
+  return (
+    <Button
+      variant="primary"
+      iconAfter={args.iconAfter}
+      onClick={args.onClick}
+    >
+      {args.label}
+    </Button>
+  );
+};
+StartGradingButton.propTypes = {
+  gradeStatus: PropTypes.string.isRequired,
+  startGrading: PropTypes.func.isRequired,
+  stopGrading: PropTypes.func.isRequired,
+};
+
+export const mapStateToProps = (state) => ({
+  gradeStatus: selectors.grading.selected.gradeStatus(state),
+});
+
+export const mapDispatchToProps = {
+  toggleShowRubric: actions.app.toggleShowRubric,
+  startGrading: thunkActions.grading.startGrading,
+  // TODO: fix
+  stopGrading: thunkActions.grading.startGrading,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(StartGradingButton);

--- a/src/data/actions/grading.js
+++ b/src/data/actions/grading.js
@@ -72,6 +72,12 @@ const rubric = StrictDict({
   updateCriterionComment: createAction('rubric/criterionComment'),
 });
 
+export const startGrading = createAction('grading/start');
+export const setRubricFeedback = createAction('grading/setRubricFeedback');
+export const setCriterionFeedback = createAction('grading/setCriterionFeedback');
+export const setCriterionOption = createAction('grading/setCriterionOption');
+export const clearGrade = createAction('grading/clear');
+
 export default StrictDict({
   loadSubmission,
   preloadNext,
@@ -80,4 +86,10 @@ export default StrictDict({
   loadPrev,
   updateSelection,
   rubric,
+
+  startGrading,
+  setRubricFeedback,
+  setCriterionFeedback,
+  setCriterionOption,
+  clearGrade,
 });

--- a/src/data/reducers/app.js
+++ b/src/data/reducers/app.js
@@ -1,3 +1,5 @@
+import { createReducer } from '@reduxjs/toolkit';
+
 import actions from 'data/actions';
 
 const initialState = {
@@ -18,22 +20,17 @@ const initialState = {
 };
 
 // eslint-disable-next-line no-unused-vars
-const app = (state = initialState, { type, payload }) => {
-  switch (type) {
-    case actions.app.loadCourseMetadata.toString():
-      return { ...state, courseMetadata: payload };
-    case actions.app.loadOraMetadata.toString():
-      return { ...state, oraMetadata: payload };
-    case actions.app.setShowReview.toString():
-      return { ...state, showReview: payload };
-    case actions.app.setGrading.toString():
-      return { ...state, grading: payload };
-    case actions.app.toggleShowRubric.toString():
-      return { ...state, showRubric: !state.showRubric };
-    default:
-      return state;
-  }
-};
+const app = createReducer(initialState, {
+  [actions.app.loadCourseMetadata]: (state, { payload }) => ({ ...state, courseMetadata: payload }),
+  [actions.app.loadOraMetadata]: (state, { payload }) => ({ ...state, oraMetadata: payload }),
+  [actions.app.setShowReview]: (state, { payload }) => ({ ...state, showReview: payload }),
+  [actions.app.setGrading]: (state, { payload }) => ({
+    ...state,
+    grading: payload,
+    showRubric: payload,
+  }),
+  [actions.app.toggleShowRubric]: (state) => ({ ...state, showRubric: !state.showRubric }),
+});
 
 export { initialState };
 export default app;

--- a/src/data/reducers/grading.js
+++ b/src/data/reducers/grading.js
@@ -1,4 +1,7 @@
+import { createReducer } from '@reduxjs/toolkit';
+
 import actions from 'data/actions';
+import selectors from 'data/selectors';
 
 const initialState = {
   selected: [
@@ -24,7 +27,7 @@ const initialState = {
      * }
      */
   },
-  activeIndex: null, // submissionId
+  activeIndex: null,
   current: {
     /**
      * gradeData: {
@@ -56,48 +59,46 @@ const initialState = {
 };
 
 // eslint-disable-next-line no-unused-vars
-const app = (state = initialState, { type, payload }) => {
-  switch (type) {
-    case actions.grading.loadSubmission.toString():
-      return {
-        ...state,
-        current: {
-          ...payload,
-        },
-        activeIndex: 0,
-      };
-    case actions.grading.preloadNext.toString():
-      return { ...state, next: payload };
-    case actions.grading.preloadPrev.toString():
-      return { ...state, prev: payload };
-    case actions.grading.loadNext.toString():
-      return {
-        ...state,
-        prev: state.current,
-        current: {
-          response: state.next.response,
-          ...payload,
-        },
-        activeIndex: state.activeIndex + 1,
-        next: null,
-      };
-    case actions.grading.loadPrev.toString():
-      return {
-        ...state,
-        next: state.current,
-        current: {
-          response: state.prev.response,
-          ...payload,
-        },
-        activeIndex: state.activeIndex - 1,
-        prev: null,
-      };
-    case actions.grading.updateSelection.toString():
-      return { ...state, selected: payload, activeIndex: 0 };
-    default:
-      return state;
-  }
-};
+const app = createReducer(initialState, {
+  [actions.grading.loadSubmission]: (state, { payload }) => ({
+    ...state,
+    current: { ...payload },
+    activeIndex: 0,
+  }),
+  [actions.grading.preloadNext]: (state, { payload }) => ({ ...state, next: payload }),
+  [actions.grading.preloadPrev]: (state, { payload }) => ({ ...state, prev: payload }),
+  [actions.grading.loadNext]: (state, { payload }) => ({
+    ...state,
+    prev: state.current,
+    current: { response: state.next.response, ...payload },
+    activeIndex: state.activeIndex + 1,
+    next: null,
+  }),
+  [actions.grading.loadPrev]: (state, { payload }) => ({
+    ...state,
+    next: state.current,
+    current: { response: state.prev.response, ...payload },
+    activeIndex: state.activeIndex - 1,
+    prev: null,
+  }),
+  [actions.grading.updateSelection]: (state, { payload }) => ({
+    ...state,
+    selected: payload,
+    activeIndex: 0,
+  }),
+  [actions.grading.startGrading]: (state, { payload }) => ({
+    ...state,
+    gradingStatus: {
+      ...state.gradingStatus,
+      [state.current.submissionId]: { ...payload },
+    },
+  }),
+  [actions.grading.clearGrade]: (state) => {
+    const gradingStatus = { ...state.gradingStatus };
+    delete gradingStatus[state.current.submissionId];
+    return { ...state, gradingStatus };
+  },
+});
 
 export { initialState };
 export default app;

--- a/src/data/reducers/grading.js
+++ b/src/data/reducers/grading.js
@@ -39,7 +39,6 @@ const initialState = {
      *   criteria: [{
      *     name: '',
      *     feedback: '',
-     *     score: 0,
      *     selectedOption: '',
      *   }],
      * }
@@ -93,6 +92,43 @@ const app = createReducer(initialState, {
       [state.current.submissionId]: { ...payload },
     },
   }),
+  [actions.grading.setRubricFeedback]: (state, { payload }) => ({
+    ...state,
+    gradingStatus: {
+      ...state.gradingStatus,
+      overallFeebadk: payload,
+    },
+  }),
+  [actions.grading.setCriterionOption]: (state, { payload: { orderNum, value } }) => {
+    const entry = state.gradingStatus[state.current.submissionId];
+    const { criteria } = entry;
+    criteria[orderNum] = { ...criteria[orderNum], selectedOption: value };
+    return {
+      ...state,
+      gradingStatus: {
+        ...state.gradingStatus,
+        [state.current.submissionId]: {
+          ...entry,
+          criteria,
+        },
+      },
+    };
+  },
+  [actions.grading.setCriterionFeedback]: (state, { payload: { orderNum, value } }) => {
+    const entry = state.gradingStatus[state.current.submissionId];
+    const { criteria } = entry;
+    criteria[orderNum] = { ...criteria[orderNum], feedback: value };
+    return {
+      ...state,
+      gradingStatus: {
+        ...state.gradingStatus,
+        [state.current.submissionId]: {
+          ...entry,
+          criteria,
+        },
+      },
+    };
+  },
   [actions.grading.clearGrade]: (state) => {
     const gradingStatus = { ...state.gradingStatus };
     delete gradingStatus[state.current.submissionId];

--- a/src/data/reducers/submissions.js
+++ b/src/data/reducers/submissions.js
@@ -1,7 +1,7 @@
 import actions from 'data/actions';
 
 const initialState = {
-  list: {
+  allSubmissions: {
     /**
      * <submissionId>: {
      *   submissionId: '',
@@ -22,7 +22,7 @@ const initialState = {
 const grades = (state = initialState, { type, payload }) => {
   switch (type) {
     case actions.submissions.loadList.toString():
-      return { ...state, list: payload };
+      return { ...state, allSubmissions: payload };
     default:
       return state;
   }

--- a/src/data/selectors/app.js
+++ b/src/data/selectors/app.js
@@ -1,3 +1,7 @@
+import { createSelector } from 'reselect';
+
+import { feedbackRequirement } from 'data/services/lms/constants';
+
 import { StrictDict } from 'utils';
 
 export const simpleSelectors = {
@@ -8,8 +12,39 @@ export const simpleSelectors = {
   oraName: state => state.app.oraMetadata.name,
   oraPrompt: state => state.app.oraMetadata.prompt,
   oraTypes: state => state.app.oraMetadata.type,
+  rubricConfig: state => state.app.oraMetadata.rubricConfig,
+};
+
+const shouldIncludeFeedback = (feedback) => ([
+  feedbackRequirement.required,
+  feedbackRequirement.optional,
+]).includes(feedback);
+
+export const emptyGrade = (state) => {
+  const { rubricConfig } = state.app.oraMetadata;
+  console.log({ rubricConfig });
+  if (rubricConfig === undefined) {
+    return null;
+  }
+  const gradeData = {};
+  if (shouldIncludeFeedback(rubricConfig.feedback)) {
+    gradeData.overallFeedback = '';
+  }
+  gradeData.criteria = rubricConfig.criteria.map(criterion => {
+    const entry = {
+      orderNum: criterion.orderNum,
+      name: criterion.name,
+      selectedOption: null,
+    };
+    if (shouldIncludeFeedback(criterion.feedback)) {
+      entry.feedback = '';
+    }
+    return entry;
+  });
+  return gradeData;
 };
 
 export default StrictDict({
   ...simpleSelectors,
+  emptyGrade,
 });

--- a/src/data/selectors/grading.js
+++ b/src/data/selectors/grading.js
@@ -34,9 +34,9 @@ export const selectedSubmissionId = createSelector(
  *  { submissionId, username, teamName, dateSubmitted }
  */
 export const selectedStaticData = createSelector(
-  [module.selectedSubmissionId, submissionsSelectors.list],
-  (submissionId, list) => {
-    const submission = list[submissionId];
+  [module.selectedSubmissionId, submissionsSelectors.allSubmissions],
+  (submissionId, allSubmissions) => {
+    const submission = allSubmissions[submissionId];
     const { grade, gradeStatus, ...staticData } = submission;
     return staticData;
   },

--- a/src/data/selectors/submissions.js
+++ b/src/data/selectors/submissions.js
@@ -2,20 +2,29 @@ import _ from 'lodash';
 import { createSelector } from 'reselect';
 
 import { StrictDict } from 'utils';
+import { lockStatuses } from 'data/services/lms/constants';
 
 export const simpleSelectors = {
-  list: state => state.submissions.list,
+  allSubmissions: state => state.submissions.allSubmissions,
 };
 
 /**
  * Returns the submission list in default order for the table.
  */
 export const listData = createSelector(
-  [simpleSelectors.list],
-  (list) => _.sortBy(
-    Object.values(list),
-    ['submissionId'],
-  ),
+  [simpleSelectors.allSubmissions],
+  (allSubmissions) => {
+    const submissionIds = Object.keys(allSubmissions);
+    const submissionList = submissionIds.map(id => {
+      const { gradeStatus, lockStatus, ...rest } = allSubmissions[id];
+      const gradingStatus = (lockStatus === lockStatuses.unlocked ? gradeStatus : lockStatus);
+      return { gradingStatus, ...rest };
+    });
+    return _.sortBy(
+      submissionList,
+      ['submissionDate'],
+    );
+  },
 );
 
 export default StrictDict({

--- a/src/data/services/lms/api.js
+++ b/src/data/services/lms/api.js
@@ -91,9 +91,9 @@ export const fetchSubmissionResponse = mockSuccess((submissionId) => ({
  * @param {bool} value - new lock value
  * @param {string} submissionId
  */
-const lockSubmission = mockSuccess(({ value, submissionId }) => {
-  console.log({ lockSubmission: { value, submissionId } });
-});
+const lockSubmission = mockSuccess(() => ({
+  response: true,
+}));
 
 /*
  * Assuming we do not care who has locked it or why, as there
@@ -102,9 +102,9 @@ const lockSubmission = mockSuccess(({ value, submissionId }) => {
  * @param {bool} value - new lock value
  * @param {string} submissionId
  */
-const lockSubmissionFail = mockFailure(({ value, submissionId }) => {
-  console.log({ lockSubmissionFail: { value, submissionId } });
-});
+const lockSubmissionFail = mockFailure(() => ({
+  error: 'that did not work',
+}));
 
 /*
  * post('api/updateGrade', { submissionId, gradeData })

--- a/src/data/services/lms/constants.js
+++ b/src/data/services/lms/constants.js
@@ -1,15 +1,32 @@
 import { StrictDict } from 'utils';
 
-export const gradingStatuses = StrictDict({
-  ungraded: 'ungraded',
-  graded: 'graded',
+export const lockStatuses = StrictDict({
+  unlocked: 'unlocked',
   locked: 'locked',
   inProgress: 'in-progress',
 });
 
+export const gradeStatuses = StrictDict({
+  ungraded: 'ungraded',
+  graded: 'graded',
+});
+
+export const gradingStatuses = StrictDict({
+  ungraded: gradeStatuses.ungraded,
+  graded: gradeStatuses.graded,
+  locked: lockStatuses.locked,
+  inProgress: lockStatuses.inProgress,
+});
+
 export const gradingStatusDisplay = StrictDict({
   [gradingStatuses.ungraded]: 'Ungraded',
-  [gradingStatuses.locked]: 'Grading In Progress',
+  [gradingStatuses.locked]: 'Currently being graded by someone else',
   [gradingStatuses.graded]: 'Grading Complete',
-  [gradingStatuses.inProgress]: 'Locked by you',
+  [gradingStatuses.inProgress]: 'You are currently grading this response',
+});
+
+export const feedbackRequirement = StrictDict({
+  disabled: 'disabled',
+  required: 'required',
+  optional: 'optional',
 });

--- a/src/data/services/lms/fakeData/index.js
+++ b/src/data/services/lms/fakeData/index.js
@@ -4,6 +4,15 @@ import oraMetadata from './ora';
 import courseMetadata from './course';
 import ids from './ids';
 
+console.log({
+  submissions,
+  oraMetadata,
+  courseMetadata,
+  mockSubmission,
+  mockSubmissionStatus,
+  ids,
+});
+
 export default {
   submissions,
   oraMetadata,

--- a/src/data/services/lms/fakeData/ora.js
+++ b/src/data/services/lms/fakeData/ora.js
@@ -12,7 +12,7 @@ export const name = 'This is the Name of the ORA';
 export const type = 'individual';
 
 const rubricConfig = {
-  comments: 'rubric-level comments',
+  feedback: 'optional',
   criteria: [
     {
       name: 'firstCriterion',

--- a/src/data/services/lms/fakeData/submissionList.js
+++ b/src/data/services/lms/fakeData/submissionList.js
@@ -1,5 +1,5 @@
 import ids from './ids';
-import { gradingStatuses as statuses } from '../constants';
+import { gradeStatuses, lockStatuses } from '../constants';
 
 /**
  * Response entries, with identifier.
@@ -22,7 +22,7 @@ const day = 86400000;
 const submissions = {};
 let lastIndex = 0;
 
-const createSubmission = (score, gradeStatus) => {
+const createSubmission = (score, gradeStatus, lockStatus) => {
   const index = lastIndex;
   lastIndex += 1;
   const submissionId = ids.submissionId(index);
@@ -32,7 +32,7 @@ const createSubmission = (score, gradeStatus) => {
     criteria: [{
       name: 'firstCriterion',
       feedback: 'did alright',
-      selectedOption: 'good'
+      selectedOption: 'good',
     }],
   };
   submissions[submissionId] = {
@@ -43,22 +43,31 @@ const createSubmission = (score, gradeStatus) => {
     score,
     gradeData,
     gradeStatus,
+    lockStatus,
   };
 };
 
-for (let i = 0; i < 20; i++) {
-  createSubmission(null, statuses.ungraded);
+for (let i = 0; i < 10; i++) {
+  createSubmission(null, gradeStatuses.ungraded, lockStatuses.unlocked);
   createSubmission(
     { pointsEarned: 70 + i, pointsPossible: 100 },
-    statuses.locked,
+    gradeStatuses.graded,
+    lockStatuses.locked,
   );
   createSubmission(
     { pointsEarned: 80 + i, pointsPossible: 100 },
-    statuses.graded,
+    gradeStatuses.graded,
+    lockStatuses.unlocked,
   );
   createSubmission(
     null,
-    statuses.inProgress,
+    gradeStatuses.ungraded,
+    lockStatuses.inProgress,
+  );
+  createSubmission(
+    { pointsEarned: 90 + i, pointsPossible: 100 },
+    gradeStatuses.graded,
+    lockStatuses.inProgress,
   );
 }
 

--- a/src/data/thunkActions/app.js
+++ b/src/data/thunkActions/app.js
@@ -11,7 +11,6 @@ const locationId = window.location.pathname.slice(1);
  */
 export const initialize = () => (dispatch) => (
   api.initializeApp(locationId).then((response) => {
-    console.log({ response });
     dispatch(actions.app.loadOraMetadata(response.oraMetadata));
     dispatch(actions.app.loadCourseMetadata(response.courseMetadata));
     dispatch(actions.submissions.loadList(response.submissions));

--- a/src/data/thunkActions/app.js
+++ b/src/data/thunkActions/app.js
@@ -11,6 +11,7 @@ const locationId = window.location.pathname.slice(1);
  */
 export const initialize = () => (dispatch) => (
   api.initializeApp(locationId).then((response) => {
+    console.log({ response });
     dispatch(actions.app.loadOraMetadata(response.oraMetadata));
     dispatch(actions.app.loadCourseMetadata(response.courseMetadata));
     dispatch(actions.submissions.loadList(response.submissions));

--- a/src/data/thunkActions/grading.js
+++ b/src/data/thunkActions/grading.js
@@ -3,6 +3,7 @@ import { StrictDict } from 'utils';
 import actions from 'data/actions';
 import selectors from 'data/selectors';
 import api from 'data/services/lms/api';
+import { gradingStatuses as statuses } from 'data/services/lms/constants';
 import * as module from './grading';
 
 /**
@@ -32,32 +33,41 @@ export const prefetchPrev = () => (dispatch, getState) => (
  * and calls loadNext with it to update the current selection index info.
  * If the new index has a next submission available, preload its response.
  */
-export const loadNext = () => (dispatch, getState) => (
-  api.fetchSubmissionStatus(
-    selectors.grading.nextSubmissionId(getState()),
-  ).then((response) => {
-    dispatch(actions.grading.loadNext(response));
+export const loadNext = () => (dispatch, getState) => {
+  const nextId = selectors.grading.nextSubmissionId(getState());
+  return api.fetchSubmissionStatus(nextId).then((response) => {
+    console.log({ loadNext: response });
+    dispatch(actions.grading.loadNext({ ...response, submissionId: nextId }));
+    if (response.gradeStatus === statuses.inProgress) {
+      dispatch(module.startGrading());
+    } else {
+      dispatch(actions.app.setGrading(false));
+    }
     if (selectors.grading.hasNextSubmission(getState())) {
       dispatch(module.prefetchNext());
     }
-  })
-);
+  });
+};
 
 /**
  * Fetches the current status for the "previous" submission in the selected queue,
  * and calls loadPrev with it to update the current selection index info.
  * If the new index has a previous submission available, preload its response.
  */
-export const loadPrev = () => (dispatch, getState) => (
-  api.fetchSubmissionStatus(
-    selectors.grading.prevSubmissionId(getState()),
-  ).then((response) => {
-    dispatch(actions.grading.loadPrev(response));
+export const loadPrev = () => (dispatch, getState) => {
+  const prevId = selectors.grading.prevSubmissionId(getState());
+  return api.fetchSubmissionStatus(prevId).then((response) => {
+    dispatch(actions.grading.loadPrev({ ...response, submissionId: prevId }));
+    if (response.gradeStatus === statuses.inProgress) {
+      dispatch(module.startGrading());
+    } else {
+      dispatch(actions.app.setGrading(false));
+    }
     if (selectors.grading.hasPrevSubmission(getState())) {
       dispatch(module.prefetchPrev());
     }
-  })
-);
+  });
+};
 
 /**
  * Load a list of selected submissionIds, sets the app to review mode, and fetches the current
@@ -70,7 +80,10 @@ export const loadSelectionForReview = (submissionIds) => (dispatch, getState) =>
   return api.fetchSubmission(
     selectors.grading.selectedSubmissionId(getState()),
   ).then((response) => {
-    dispatch(actions.grading.loadSubmission(response));
+    dispatch(actions.grading.loadSubmission({
+      ...response,
+      submissionId: submissionIds[0],
+    }));
     dispatch(actions.app.setShowReview(true));
     if (selectors.grading.hasNextSubmission(getState())) {
       dispatch(prefetchNext());
@@ -81,8 +94,26 @@ export const loadSelectionForReview = (submissionIds) => (dispatch, getState) =>
   });
 };
 
+export const startGrading = () => (dispatch, getState) => {
+  console.log('start grading');
+  return api.lockSubmission(
+    selectors.grading.selectedSubmissionId(getState()),
+  ).then(() => {
+    console.log('succeed at locking');
+    dispatch(actions.app.setGrading(true));
+    let gradeData = selectors.grading.selected.gradeData(getState());
+    if (gradeData === undefined) {
+      gradeData = selectors.app.emptyGrade(getState());
+    }
+    dispatch(actions.grading.startGrading(gradeData));
+  }).catch((error) => {
+    console.log({ error });
+  });
+};
+
 export default StrictDict({
   loadSelectionForReview,
   loadNext,
   loadPrev,
+  startGrading,
 });


### PR DESCRIPTION
# What changed?
Separate gradingStatus into [`gradeStatus` and `lockStatus`], with gradingStatus as meta-value.

Add Grading redux methods

Add StartGrading button component to wrap the behaviors for that button.

Update navigation redux logic to accommodate grading status

add empty grade generator for starting to grade an ungraded submission

`list` selector becomes `allSubmissions` to better reflect its shape

# JIRA
[AU-317](https://openedx.atlassian.net/browse/AU-317)